### PR TITLE
style: unify product card image sizes on homepage

### DIFF
--- a/src/pages/front/Home.jsx
+++ b/src/pages/front/Home.jsx
@@ -118,37 +118,28 @@ const FeaturedProducts = ({ allproducts }) => {
                 className="col-6 col-sm-4 col-md-3 col-lg-2 mt-md-3 mt-lg-2 shadow-sm"
                 key={product.id}
               >
-                <div className="card border-0 mb-4">
-                  <div
-                    className="d-flex justify-content-center align-items-center"
-                    style={{ height: "150px" }}
+                <div className="card text-center border-0 mb-4 product-card">
+                  <Link
+                    className="text-decoration-none"
+                    to={`/products/${product.id}`}
                   >
-                    <img
-                      src={`${
-                        product.imageUrl === ""
-                          ? "https://images.unsplash.com/photo-1502743780242-f10d2ce370f3?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1916&q=80"
-                          : product.imageUrl
-                      }`}
-                      className="object-cover"
-                      style={{ maxHeight: "100%", maxWidth: "100%" }}
-                      alt="..."
-                    />
-                  </div>
-                  <div className="card-body p-2 mt-1">
-                    <div style={{ height: "44.4px" }}>
-                      <p>
-                        <Link
-                          className="text-decoration-none"
-                          to={`/products/${product.id}`}
-                        >
-                          {product.title}
-                        </Link>
-                      </p>
+                    <div className="d-flex justify-content-center align-items-center product-card__image-wrapper">
+                      <img
+                        src={`${
+                          product.imageUrl === ""
+                            ? "https://images.unsplash.com/photo-1502743780242-f10d2ce370f3?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1916&q=80"
+                            : product.imageUrl
+                        }`}
+                        className="object-cover product-card__image"
+                        alt="..."
+                      />
                     </div>
-                    <div
-                      className="d-flex flex-column justify-content-between"
-                      style={{ minHeight: "10px" }}
-                    >
+                    <div className="mt-3 product-card__link-wrapper">
+                      <p>{product.title}</p>
+                    </div>
+                  </Link>
+                  <div className="card-body p-0 product-card__body">
+                    <div className="d-flex flex-column">
                       <p className="text-nowrap">{`${product.price}元`}</p>
                       <p className="card-text text-muted">{product.content}</p>
                     </div>

--- a/src/styles/_utilities.scss
+++ b/src/styles/_utilities.scss
@@ -18,7 +18,9 @@ $orange: #ffa500;
 /* 顯示搜尋結果效果 */
 
 .card-hover {
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  transition:
+    transform 0.3s ease,
+    box-shadow 0.3s ease;
 
   &:hover {
     transform: translateY(-5px) scale(1.05);
@@ -79,6 +81,23 @@ $orange: #ffa500;
     &.active {
       font-weight: bold;
     }
+  }
+}
+
+.product-card {
+  &__image-wrapper {
+    height: 150px;
+    width: 100%;
+  }
+
+  &__image {
+    width: 100%;
+    height: 100%;
+    object-position: center;
+  }
+
+  &__link-wrapper {
+    height: 66.6px;
   }
 }
 


### PR DESCRIPTION
changes
- Adjusted the product card image styles on the homepage
- Made both product images and titles clickable
- Replaced all inline styles in product cards with CSS classes

checklist
- [x] Images ard align correctly on all screen sizes
- [x] No layout issues
- [x] Both the product image and title are clickable